### PR TITLE
add entrant count sync and location radius with km conversion

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation("org.robolectric:robolectric:4.11.1")
     testImplementation("org.mockito:mockito-core:5.7.0")
+    testImplementation("org.quicktheories:quicktheories:0.26")
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.5.1") {

--- a/code/app/src/main/res/layout/organizer_create_event.xml
+++ b/code/app/src/main/res/layout/organizer_create_event.xml
@@ -272,6 +272,33 @@
                     android:layout_marginLeft="0dp"/>
             </LinearLayout>
 
+            <!-- Maximum distance (shown when location toggle is on) -->
+            <LinearLayout
+                android:id="@+id/layoutMaxDistance"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:visibility="gone">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginLeft="50dp"
+                    android:text="Maximum Distance (km)"
+                    android:textStyle="bold" />
+
+                <EditText
+                    android:id="@+id/editMaxDistance"
+                    android:layout_width="100dp"
+                    android:layout_height="wrap_content"
+                    android:hint="500"
+                    android:inputType="number"
+                    android:background="@android:drawable/edit_text"
+                    android:padding="8dp" />
+            </LinearLayout>
+
             <!-- Confirm button -->
             <Button
                 android:id="@+id/buttonConfirm"

--- a/code/app/src/main/res/layout/organizer_edit_event_fragment.xml
+++ b/code/app/src/main/res/layout/organizer_edit_event_fragment.xml
@@ -389,14 +389,14 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:layout_marginLeft="50dp"
-                    android:text="Maximum Distance"
+                    android:text="Maximum Distance (km)"
                     android:textStyle="bold" />
 
                 <EditText
                     android:id="@+id/editMaxDistance"
                     android:layout_width="60dp"
                     android:layout_height="wrap_content"
-                    android:hint="10m"
+                    android:hint="500"
                     android:inputType="number"
                     android:background="@android:drawable/edit_text"
                     android:padding="8dp" />


### PR DESCRIPTION
- Auto-sync currentEntrants when waitlist changes (For organizer view)
- Add location radius field (1-500km) with meter/km conversion
- Fix edit screen save behavior and value persistence for location settings