### PR TITLE
fix: resolved Firestore serialization crash with String-keyed maps

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -22,6 +22,10 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        
+        // Read Google Maps API key from local.properties
+        val mapsApiKey: String = project.findProperty("MAPS_API_KEY") as String? ?: "YOUR_GOOGLE_MAPS_API_KEY_HERE"
+        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
     }
 
     buildTypes {
@@ -81,6 +85,7 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.android.gms:play-services-location:21.3.0")
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
     implementation("com.google.guava:guava:31.1-android")
     implementation("androidx.camera:camera-camera2:1.5.1")
     implementation("com.google.zxing:core:3.5.4")

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Google Maps API Key (loaded from local.properties) -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
     </application>
 
 </manifest>

--- a/code/app/src/main/java/com/example/slices/fragments/EntrantMapFragment.java
+++ b/code/app/src/main/java/com/example/slices/fragments/EntrantMapFragment.java
@@ -1,0 +1,240 @@
+package com.example.slices.fragments;
+
+import android.location.Location;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.slices.R;
+import com.example.slices.controllers.EventController;
+import com.example.slices.interfaces.EventCallback;
+import com.example.slices.models.Entrant;
+import com.example.slices.models.Event;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.MarkerOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fragment for displaying entrant join locations on a map
+ * Implements US 02.02.02 - Show where entrants joined from
+ */
+public class EntrantMapFragment extends Fragment implements OnMapReadyCallback {
+
+    private static final String ARG_EVENT_ID = "event_id";
+    private static final String ARG_EVENT_NAME = "event_name";
+
+    private int eventId;
+    private String eventName;
+    private GoogleMap googleMap;
+    private Event currentEvent;
+
+    public static EntrantMapFragment newInstance(int eventId, String eventName) {
+        EntrantMapFragment fragment = new EntrantMapFragment();
+        Bundle args = new Bundle();
+        args.putInt(ARG_EVENT_ID, eventId);
+        args.putString(ARG_EVENT_NAME, eventName);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            eventId = getArguments().getInt(ARG_EVENT_ID, -1);
+            eventName = getArguments().getString(ARG_EVENT_NAME, "Event");
+        }
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_entrant_map, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        // Set up toolbar back button
+        com.google.android.material.appbar.MaterialToolbar toolbar = view.findViewById(R.id.toolbar);
+        toolbar.setNavigationOnClickListener(v -> {
+            if (getActivity() != null) {
+                getActivity().onBackPressed();
+            }
+        });
+
+        // Initialize map
+        SupportMapFragment mapFragment = (SupportMapFragment) getChildFragmentManager()
+                .findFragmentById(R.id.map);
+        if (mapFragment != null) {
+            mapFragment.getMapAsync(this);
+        }
+    }
+
+    @Override
+    public void onMapReady(@NonNull GoogleMap map) {
+        this.googleMap = map;
+
+        // Configure map
+        googleMap.getUiSettings().setZoomControlsEnabled(true);
+        googleMap.getUiSettings().setMyLocationButtonEnabled(false);
+
+        // Load event data and display locations
+        loadEventAndDisplayLocations();
+    }
+
+    private void loadEventAndDisplayLocations() {
+        if (eventId == -1) {
+            showError("Invalid event ID");
+            return;
+        }
+
+        EventController.getEvent(eventId, new EventCallback() {
+            @Override
+            public void onSuccess(Event event) {
+                if (getActivity() != null) {
+                    getActivity().runOnUiThread(() -> {
+                        currentEvent = event;
+                        displayEntrantLocations();
+                    });
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (getActivity() != null) {
+                    getActivity().runOnUiThread(() -> {
+                        showError("Failed to load event: " + e.getMessage());
+                    });
+                }
+            }
+        });
+    }
+
+    private void displayEntrantLocations() {
+        if (currentEvent == null || googleMap == null) return;
+
+        // Check if geolocation is enabled for this event
+        if (!currentEvent.getEventInfo().getEntrantLoc()) {
+            showError("Location tracking is not enabled for this event");
+            return;
+        }
+
+        // Get entrant locations from waitlist
+        Map<String, Map<String, Double>> entrantLocations = 
+            currentEvent.getWaitlist().getEntrantLocations();
+
+        if (entrantLocations == null || entrantLocations.isEmpty()) {
+            showError("No location data available for entrants");
+            return;
+        }
+
+        // Add markers for each entrant location
+        List<LatLng> positions = new ArrayList<>();
+        int markerCount = 0;
+
+        for (Map.Entry<String, Map<String, Double>> entry : entrantLocations.entrySet()) {
+            String entrantIdStr = entry.getKey();
+            Map<String, Double> locationMap = entry.getValue();
+
+            if (locationMap != null && 
+                locationMap.containsKey("latitude") && 
+                locationMap.containsKey("longitude")) {
+                
+                double lat = locationMap.get("latitude");
+                double lng = locationMap.get("longitude");
+                LatLng position = new LatLng(lat, lng);
+
+                // Convert String ID back to Integer for lookup
+                int entrantId;
+                try {
+                    entrantId = Integer.parseInt(entrantIdStr);
+                } catch (NumberFormatException e) {
+                    // Skip this entry if ID cannot be parsed
+                    continue;
+                }
+                
+                // Get entrant name if available
+                String entrantName = getEntrantName(entrantId);
+
+                // Add marker
+                googleMap.addMarker(new MarkerOptions()
+                        .position(position)
+                        .title(entrantName)
+                        .snippet("Joined from this location"));
+
+                positions.add(position);
+                markerCount++;
+            }
+        }
+
+        // Show count
+        Toast.makeText(getContext(), 
+            "Showing " + markerCount + " entrant location(s)", 
+            Toast.LENGTH_SHORT).show();
+
+        // Zoom camera to show all markers
+        if (!positions.isEmpty()) {
+            zoomToShowAllMarkers(positions);
+        }
+    }
+
+    private String getEntrantName(int entrantId) {
+        if (currentEvent == null || currentEvent.getWaitlist() == null) {
+            return "Entrant #" + entrantId;
+        }
+
+        Entrant entrant = currentEvent.getWaitlist().getEntrant(entrantId);
+        if (entrant != null && entrant.getProfile() != null && 
+            entrant.getProfile().getName() != null) {
+            return entrant.getProfile().getName();
+        }
+
+        return "Entrant #" + entrantId;
+    }
+
+    private void zoomToShowAllMarkers(List<LatLng> positions) {
+        if (positions.isEmpty() || googleMap == null) return;
+
+        LatLngBounds.Builder builder = new LatLngBounds.Builder();
+        for (LatLng position : positions) {
+            builder.include(position);
+        }
+
+        LatLngBounds bounds = builder.build();
+        int padding = 100; // padding in pixels
+
+        try {
+            googleMap.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, padding));
+        } catch (Exception e) {
+            // If animation fails, try without animation
+            googleMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, padding));
+        }
+    }
+
+    private void showError(String message) {
+        if (getContext() != null) {
+            Toast.makeText(getContext(), message, Toast.LENGTH_LONG).show();
+        }
+        // Optionally close the fragment or navigate back
+        if (getActivity() != null) {
+            getActivity().onBackPressed();
+        }
+    }
+}

--- a/code/app/src/main/java/com/example/slices/fragments/OrganizerCreateEventFragment.java
+++ b/code/app/src/main/java/com/example/slices/fragments/OrganizerCreateEventFragment.java
@@ -312,9 +312,9 @@ public class OrganizerCreateEventFragment extends Fragment {
             //Placeholder image
             String imgUrl = "https://cdn.mos.cms.futurecdn.net/39CUYMP8vJqHAYGVzUghBX.jpg";
 
-            // Build an eventInfo
+            // Build an eventInfo (location not passed - not stored in Firebase)
             EventInfo eventInfo = new EventInfo(name, desc, address, guide, imgUrl, eventTimestamp, regStartTimestamp, regEndTimestamp,
-                    maxParticipants, maxWaiting, entrantLoc, entrantDist, 0, organizerID, location);
+                    maxParticipants, maxWaiting, entrantLoc, entrantDist, 0, organizerID);
 
 
             // Create event object - use testing constructor to bypass validation

--- a/code/app/src/main/java/com/example/slices/models/Event.java
+++ b/code/app/src/main/java/com/example/slices/models/Event.java
@@ -8,6 +8,7 @@ import com.example.slices.exceptions.EntrantNotFound;
 import com.example.slices.exceptions.EventFull;
 import com.example.slices.exceptions.WaitlistFull;
 import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.IgnoreExtraProperties;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.Objects;
  * @version 1.5
  *
  */
+@IgnoreExtraProperties
 public class Event implements Comparable<Event> {
 
     /**
@@ -38,6 +40,7 @@ public class Event implements Comparable<Event> {
     private EventInfo eventInfo;
     private List<Integer> entrantIds;
 
+    @com.google.firebase.firestore.Exclude
     private ArrayList<Location> entrantLocs;
 
 
@@ -52,10 +55,9 @@ public class Event implements Comparable<Event> {
 
     public Event(String name, String description, String address, String guidelines, String imgUrl,
                  Timestamp eventDate, Timestamp regStart, Timestamp regEnd, int maxEntrants,
-                 int maxWaiting, boolean entrantLoc, String entrantDist, int id, int organizerID,
-                 Location location)  {
+                 int maxWaiting, boolean entrantLoc, String entrantDist, int id, int organizerID)  {
         this.eventInfo = new EventInfo(name, description, address,  guidelines, imgUrl,
-                eventDate, regStart, regEnd, maxEntrants, maxWaiting, entrantLoc, entrantDist, id, organizerID, location);
+                eventDate, regStart, regEnd, maxEntrants, maxWaiting, entrantLoc, entrantDist, id, organizerID);
         this.id = id;
         this.entrants = new ArrayList<Entrant>();
         this.waitlist = new Waitlist(maxWaiting);
@@ -144,6 +146,17 @@ public class Event implements Comparable<Event> {
      *      Entrant to add to the waitlist
      */
     public boolean addEntrantToWaitlist(Entrant entrant) {
+        return addEntrantToWaitlist(entrant, null);
+    }
+    
+    /**
+     * Adds an entrant to the event's waitlist with their join location
+     * @param entrant
+     *      Entrant to add to the waitlist
+     * @param location
+     *      Location where the entrant joined (can be null)
+     */
+    public boolean addEntrantToWaitlist(Entrant entrant, Location location) {
         //Check if the waitlist is full
         if (waitlist.getEntrants().size() >= waitlist.getMaxCapacity()) {
             throw new WaitlistFull("Waitlist is full");
@@ -154,6 +167,10 @@ public class Event implements Comparable<Event> {
         }
         //Otherwise add the entrant to the waitlist
         waitlist.addEntrant(entrant);
+        //Store the location if provided
+        if (location != null) {
+            waitlist.setEntrantLocation(entrant.getId(), location);
+        }
         return true;
     }
 

--- a/code/app/src/main/java/com/example/slices/models/EventInfo.java
+++ b/code/app/src/main/java/com/example/slices/models/EventInfo.java
@@ -4,7 +4,10 @@ import android.location.Location;
 
 import com.example.slices.interfaces.DBWriteCallback;
 import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.Exclude;
+import com.google.firebase.firestore.IgnoreExtraProperties;
 
+@IgnoreExtraProperties
 public class EventInfo {
     /**
      * Name of the event
@@ -16,7 +19,9 @@ public class EventInfo {
     private String description; // Probably will be it's own thing later
     /**
      * Location of the event
+     * Excluded from Firebase serialization as Location is not a simple POJO
      */
+    @Exclude
     private Location location;
 
     private String address;
@@ -74,10 +79,10 @@ public class EventInfo {
 
     public EventInfo(String name, String description, String address, String guidelines,
                      String imgUrl, Timestamp eventDate, Timestamp regStart, Timestamp regEnd,
-                     int maxEntrants, int maxWaiting, boolean entrantLoc, String entrantDist, int id, int organizerID, Location location) {
+                     int maxEntrants, int maxWaiting, boolean entrantLoc, String entrantDist, int id, int organizerID) {
         this.name = name;
         this.description = description;
-        this.location = location;
+        this.location = null; // Not stored in Firebase, only used in memory for validation
         this.eventDate = eventDate;
         this.regStart = regStart;
         this.regEnd = regEnd;
@@ -145,6 +150,7 @@ public class EventInfo {
 
 
 
+    @Exclude
     public Location getLocation() {
         return location;
     }
@@ -160,10 +166,11 @@ public class EventInfo {
     /**
      * INTERNAL USE ONLY - Firestore requires this setter
      * Do NOT call this method directly. Use the update counterpart instead.
+     * Excluded from Firebase serialization as Location is not a simple POJO
      * @param location
      *      Location to set
      */
-
+    @Exclude
     public void setLocation(Location location) {
         this.location = location;
 

--- a/code/app/src/main/java/com/example/slices/models/Waitlist.java
+++ b/code/app/src/main/java/com/example/slices/models/Waitlist.java
@@ -1,14 +1,18 @@
 package com.example.slices.models;
 
+import android.location.Location;
+
 import com.google.firebase.firestore.IgnoreExtraProperties;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class representing a waitlist for an event
  * @author Ryan Haubrich
- * @version 1.5
+ * @version 1.6
  */
 
 @IgnoreExtraProperties
@@ -29,6 +33,14 @@ public class Waitlist {
      * Current number of entrants on the waitlist
      */
     private int currentEntrants;
+    
+    /**
+     * Map of entrant IDs to their join locations (latitude, longitude)
+     * Stored as Map<String, Map<String, Double>> for Firestore compatibility
+     * Entrant IDs are converted to Strings as Firestore requires String keys
+     * Inner map has keys: "latitude" and "longitude"
+     */
+    private Map<String, Map<String, Double>> entrantLocations;
 
     /**
      * Default constructor for Waitlist
@@ -39,6 +51,7 @@ public class Waitlist {
         this.currentEntrants = 0;
         this.maxCapacity = 32768;
         this.entrantIds = new ArrayList<>();
+        this.entrantLocations = new HashMap<>();
     }
 
     /**
@@ -51,6 +64,7 @@ public class Waitlist {
         this.maxCapacity = maxCapacity;
         this.currentEntrants = 0;
         this.entrantIds = new ArrayList<>();
+        this.entrantLocations = new HashMap<>();
     }
 
     /**
@@ -191,5 +205,71 @@ public class Waitlist {
      */
     public void setCurrentEntrants(int currentEntrants) {
         this.currentEntrants = currentEntrants;
+    }
+    
+    /**
+     * Stores the location where an entrant joined the waitlist
+     * @param entrantId
+     *      ID of the entrant
+     * @param location
+     *      Location where they joined (can be null if location not required)
+     */
+    public void setEntrantLocation(int entrantId, Location location) {
+        if (location != null) {
+            // Initialize map if null (for backward compatibility with existing events)
+            if (entrantLocations == null) {
+                entrantLocations = new HashMap<>();
+            }
+            Map<String, Double> locationMap = new HashMap<>();
+            locationMap.put("latitude", location.getLatitude());
+            locationMap.put("longitude", location.getLongitude());
+            // Convert Integer ID to String key for Firestore compatibility
+            entrantLocations.put(String.valueOf(entrantId), locationMap);
+        }
+    }
+    
+    /**
+     * Gets the location where an entrant joined the waitlist
+     * @param entrantId
+     *      ID of the entrant
+     * @return
+     *      Location object, or null if no location was stored
+     */
+    public Location getEntrantLocation(int entrantId) {
+        // Return null if map is not initialized (backward compatibility)
+        if (entrantLocations == null) {
+            return null;
+        }
+        // Convert Integer ID to String key for lookup
+        Map<String, Double> locationMap = entrantLocations.get(String.valueOf(entrantId));
+        if (locationMap != null && locationMap.containsKey("latitude") && locationMap.containsKey("longitude")) {
+            Location location = new Location("stored");
+            location.setLatitude(locationMap.get("latitude"));
+            location.setLongitude(locationMap.get("longitude"));
+            return location;
+        }
+        return null;
+    }
+    
+    /**
+     * Gets all entrant locations as a map
+     * @return
+     *      Map of entrant IDs (as Strings) to their join locations (never null, returns empty map if not initialized)
+     */
+    public Map<String, Map<String, Double>> getEntrantLocations() {
+        // Return empty map if not initialized (backward compatibility)
+        if (entrantLocations == null) {
+            return new HashMap<>();
+        }
+        return entrantLocations;
+    }
+    
+    /**
+     * Setter for entrant locations (for Firestore deserialization)
+     * @param entrantLocations
+     *      Map of entrant locations with String keys
+     */
+    public void setEntrantLocations(Map<String, Map<String, Double>> entrantLocations) {
+        this.entrantLocations = entrantLocations != null ? entrantLocations : new HashMap<>();
     }
 }

--- a/code/app/src/main/res/layout/event_entrants_fragment.xml
+++ b/code/app/src/main/res/layout/event_entrants_fragment.xml
@@ -225,5 +225,15 @@
 
     </androidx.core.widget.NestedScrollView>
 
+    <!-- Map FAB (bottom right) -->
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_show_map"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/show_map"
+        app:srcCompat="@android:drawable/ic_dialog_map"
+        app:tint="@android:color/white" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/code/app/src/main/res/layout/fragment_entrant_map.xml
+++ b/code/app/src/main/res/layout/fragment_entrant_map.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- AppBar -->
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/entrant_locations"
+            app:navigationIcon="@drawable/ic_arrow_back" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- Map Container -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <fragment
+            android:id="@+id/map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/code/app/src/main/res/navigation/nav_graph.xml
+++ b/code/app/src/main/res/navigation/nav_graph.xml
@@ -133,7 +133,24 @@
         android:id="@+id/EventEntrantsFragment"
         android:name="com.example.slices.fragments.EventEntrantsFragment"
         android:label="Event Entrants"
-        tools:layout="@layout/event_entrants_fragment" />
+        tools:layout="@layout/event_entrants_fragment">
+        <action
+            android:id="@+id/action_EventEntrantsFragment_to_EntrantMapFragment"
+            app:destination="@id/EntrantMapFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/EntrantMapFragment"
+        android:name="com.example.slices.fragments.EntrantMapFragment"
+        android:label="Entrant Locations"
+        tools:layout="@layout/fragment_entrant_map">
+        <argument
+            android:name="event_id"
+            app:argType="integer" />
+        <argument
+            android:name="event_name"
+            app:argType="string" />
+    </fragment>
 
     <action
         android:id="@+id/action_to_adminHomeFragment"

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     <string name="no_entrants_selected">Please select at least one entrant</string>
     <string name="notification_title_required">Please enter a notification title</string>
     <string name="notification_message_required">Please enter a notification message</string>
+    
+    <!-- Map strings -->
+    <string name="show_map">Show entrant locations on map</string>
+    <string name="entrant_locations">Entrant Locations</string>
+    <string name="no_locations_available">No location data available for entrants</string>
+    <string name="location_not_enabled">This event does not have geolocation enabled</string>
+    
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
- Convert Waitlist.entrantLocations from Map<Integer, Map<String, Double>> to Map<String, Map<String, Double>> for Firestore compatibility

- Add String.valueOf() conversion in setEntrantLocation() and getEntrantLocation()

- Update EntrantMapFragment to handle String-keyed location maps
- Fix map navigation to use Navigation Component instead of manual transactions
- Add EntrantMapFragment to navigation graph with proper arguments
- Move map FAB from bottom-left to bottom-right in event_entrants_fragment.xml
- Add Google Maps API key configuration to AndroidManifest.xml (i didn't push this obviously)
- Improve null safety in EventEntrantsFragment with better error handling

Fixes crash when loading events with location tracking from Firestore. Events can now be saved and loaded without deserialization errors.