### PR TITLE
Fix join/leave race conditions

### DIFF
--- a/code/app/src/main/java/com/example/slices/controllers/EventController.java
+++ b/code/app/src/main/java/com/example/slices/controllers/EventController.java
@@ -854,7 +854,7 @@ public class EventController {
         //Run a check for the locations
         if (!checkLocs(event, loc)) {
             Logger.logError("Location not in event id=" + event.getId(), null);
-            callback.onFailure(new Exception("Location not in event"));
+            callback.onFailure(new Exception("This event isn't available in your area"));
             return;
         }
         

--- a/code/app/src/main/java/com/example/slices/fragments/EventDetailsFragment.java
+++ b/code/app/src/main/java/com/example/slices/fragments/EventDetailsFragment.java
@@ -178,6 +178,7 @@ public class EventDetailsFragment extends Fragment {
                             isWaitlisted = false;
                             vm.removeWaitlistedId(eventIdStr);
                             updateWaitlistButton(isWaitlisted);
+                            binding.btnJoinWaitlist.setEnabled(true);
                             
                             // Display specific error message
                             String errorMsg = e1.getMessage();
@@ -193,6 +194,7 @@ public class EventDetailsFragment extends Fragment {
                     isWaitlisted = false;
                     vm.removeWaitlistedId(eventIdStr);
                     updateWaitlistButton(isWaitlisted);
+                    binding.btnJoinWaitlist.setEnabled(true);
                     Toast.makeText(requireContext(),
                             "Location permission required to join this event.",
                             Toast.LENGTH_SHORT).show();
@@ -242,6 +244,7 @@ public class EventDetailsFragment extends Fragment {
                     isWaitlisted = false;
                     vm.removeWaitlistedId(eventIdStr);
                     updateWaitlistButton(isWaitlisted);
+                    binding.btnJoinWaitlist.setEnabled(true);
                     
                     // Show helpful error message
                     String errorMsg = "Unable to get your location. Please:\n" +
@@ -279,16 +282,23 @@ public class EventDetailsFragment extends Fragment {
 
             // checks to see if waitlisted and communicating with DB for join/leave functions
             if (isWaitlisted) {
-                // Optimistically update UI
-                isWaitlisted = false;
-                updateWaitlistButton(isWaitlisted);
+                // Disable button and show "Leaving..." state
+                binding.btnJoinWaitlist.setEnabled(false);
+                binding.btnJoinWaitlist.setText("Leaving...");
                 
                 EventController.removeEntrantFromWaitlist(e, vm.getUser(), new DBWriteCallback() {
                     @Override
                     public void onSuccess() {
                         // Update ViewModel only after database operation succeeds
                         vm.removeWaitlistedId(eventIdStr);
+                        isWaitlisted = false;
                         android.util.Log.d("EventDetailsFragment", "Successfully left waitlist for event " + eventIdStr);
+                        
+                        // Only update UI if fragment is still attached
+                        if (isAdded()) {
+                            updateWaitlistButton(isWaitlisted);
+                            binding.btnJoinWaitlist.setEnabled(true);
+                        }
                         
                         // Refresh the event object from database after successful removal
                         EventController.getEvent(eventId, new EventCallback() {
@@ -313,6 +323,7 @@ public class EventDetailsFragment extends Fragment {
                         // Revert UI state on exception
                         isWaitlisted = true;
                         updateWaitlistButton(isWaitlisted);
+                        binding.btnJoinWaitlist.setEnabled(true);
                         
                         // Provide specific error message based on failure type
                         String errorMessage;
@@ -328,9 +339,9 @@ public class EventDetailsFragment extends Fragment {
                     }
                 });
             } else {
-                isWaitlisted = true;
-                vm.addWaitlistedId(eventIdStr);
-                updateWaitlistButton(isWaitlisted);
+                // Disable button and show "Joining..." state
+                binding.btnJoinWaitlist.setEnabled(false);
+                binding.btnJoinWaitlist.setText("Joining...");
                 
                 // Check if event requires geolocation
                 boolean requiresLocation = e.getEventInfo() != null && e.getEventInfo().getEntrantLoc();
@@ -409,7 +420,12 @@ public class EventDetailsFragment extends Fragment {
                     EventController.addEntrantToWaitlist(e, vm.getUser(), location, new DBWriteCallback() {
                         @Override
                         public void onSuccess() {
+                            vm.addWaitlistedId(eventIdStr);
+                            isWaitlisted = true;
+                            
                             if (isAdded()) {
+                                updateWaitlistButton(isWaitlisted);
+                                binding.btnJoinWaitlist.setEnabled(true);
                                 Toast.makeText(requireContext(), 
                                     "Successfully joined waitlist!", 
                                     Toast.LENGTH_SHORT).show();
@@ -437,6 +453,7 @@ public class EventDetailsFragment extends Fragment {
                             isWaitlisted = false;
                             vm.removeWaitlistedId(eventIdStr);
                             updateWaitlistButton(isWaitlisted);
+                            binding.btnJoinWaitlist.setEnabled(true);
                             Toast.makeText(requireContext(),
                                     "Failed to join waitlist. " + e1.getMessage(),
                                     Toast.LENGTH_SHORT).show();
@@ -444,14 +461,15 @@ public class EventDetailsFragment extends Fragment {
                     });
                 } else {
                     // Join without location
-                    Toast.makeText(requireContext(), 
-                        "Joining waitlist without location...", 
-                        Toast.LENGTH_SHORT).show();
-                    
                     EventController.addEntrantToWaitlist(e, vm.getUser(), new DBWriteCallback() {
                         @Override
                         public void onSuccess() {
+                            vm.addWaitlistedId(eventIdStr);
+                            isWaitlisted = true;
+                            
                             if (isAdded()) {
+                                updateWaitlistButton(isWaitlisted);
+                                binding.btnJoinWaitlist.setEnabled(true);
                                 Toast.makeText(requireContext(), 
                                     "Successfully joined waitlist!", 
                                     Toast.LENGTH_SHORT).show();
@@ -479,6 +497,7 @@ public class EventDetailsFragment extends Fragment {
                             isWaitlisted = false;
                             vm.removeWaitlistedId(eventIdStr);
                             updateWaitlistButton(isWaitlisted);
+                            binding.btnJoinWaitlist.setEnabled(true);
                             Toast.makeText(requireContext(),
                                     "Failed to join waitlist. Please try again.",
                                     Toast.LENGTH_SHORT).show();

--- a/code/app/src/main/java/com/example/slices/fragments/OrganizerEditEventFragment.java
+++ b/code/app/src/main/java/com/example/slices/fragments/OrganizerEditEventFragment.java
@@ -986,13 +986,19 @@ public class OrganizerEditEventFragment extends Fragment {
         EventController.updateEventInfo(currentEvent, eventInfo, new DBWriteCallback() {
             @Override
             public void onSuccess() {
-                Toast.makeText(getContext(), "Location settings saved!", Toast.LENGTH_SHORT).show();
+                // Only show toast if fragment is still attached
+                if (isAdded() && getContext() != null) {
+                    Toast.makeText(getContext(), "Location settings saved!", Toast.LENGTH_SHORT).show();
+                }
             }
 
             @Override
             public void onFailure(Exception e) {
-                Toast.makeText(getContext(), "Failed to save location settings: " + e.getMessage(),
-                        Toast.LENGTH_SHORT).show();
+                // Only show toast if fragment is still attached
+                if (isAdded() && getContext() != null) {
+                    Toast.makeText(getContext(), "Failed to save location settings: " + e.getMessage(),
+                            Toast.LENGTH_SHORT).show();
+                }
             }
         });
     }
@@ -1058,5 +1064,52 @@ public class OrganizerEditEventFragment extends Fragment {
                 }
             }
         });
+    }
+
+    /**
+     * Called when the fragment is paused (user navigates away).
+     * Saves any pending changes to ensure data isn't lost.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+        
+        // Save any pending changes before the fragment is paused
+        if (currentEvent != null) {
+            // Save location settings if the distance field has content
+            if (switchEntrantLocation.isChecked() && !editMaxDistance.getText().toString().trim().isEmpty()) {
+                saveEntrantLocationSettings();
+            }
+            
+            // Save other fields that might have changed
+            String currentName = editEventName.getText().toString().trim();
+            if (!currentName.isEmpty() && !currentName.equals(currentEvent.getEventInfo().getName())) {
+                saveEventName();
+            }
+            
+            String maxParticipantsStr = editMaxParticipants.getText().toString().trim();
+            if (!maxParticipantsStr.isEmpty()) {
+                try {
+                    int maxParticipants = Integer.parseInt(maxParticipantsStr);
+                    if (maxParticipants != currentEvent.getEventInfo().getMaxEntrants()) {
+                        saveMaxParticipants();
+                    }
+                } catch (NumberFormatException e) {
+                    // Ignore invalid input
+                }
+            }
+            
+            String maxWaitingStr = editMaxWaiting.getText().toString().trim();
+            if (!maxWaitingStr.isEmpty()) {
+                try {
+                    int maxWaiting = Integer.parseInt(maxWaitingStr);
+                    if (maxWaiting != currentEvent.getWaitlist().getMaxCapacity()) {
+                        saveMaxWaitingCapacity();
+                    }
+                } catch (NumberFormatException e) {
+                    // Ignore invalid input
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Add non-optimistic "Joining..."/"Leaving..." button states
- Complete DB operations even when navigating away (specifically for when geolocation enabled for an event)
- Hide join button for past events
- Auto-save distance changes on fragment pause